### PR TITLE
Link to the gem's homepage from gems#show

### DIFF
--- a/app/models/app_gem.rb
+++ b/app/models/app_gem.rb
@@ -5,4 +5,8 @@ class AppGem < ApplicationRecord
   def to_param
     name
   end
+
+  def homepage_uri
+    details['homepage_uri']
+  end
 end

--- a/app/views/gems/show.html.erb
+++ b/app/views/gems/show.html.erb
@@ -3,6 +3,19 @@
   header_title @gem.name
 %>
 
+<% header_content do %>
+  <div class="flex items-center space-x-1">
+    <h1 class="mr-2 text-3xl font-bold tracking-tight text-white">
+      <%= @gem.name %>
+    </h1>
+    <% if @gem.homepage_uri.present? %>
+      <%= link_to @gem.homepage_uri, target: "_blank" do %>
+        <i class="text-xl text-white fa-solid fa-link hover:text-amber-300"></i>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>
+
 <h2 class="text-3xl font-bold tracking-tighter">Apps using the <%= @gem.name %> gem</h2>
 <ul role="list" class="divide-y divide-gray-100">
   <% @gemfiles.each do |gemfile| %>


### PR DESCRIPTION
@Shpigford This adds a link to the gems `homepage_uri` when you're on a gems show page.

Found myself looking for this every time I looked at a gem I didn't know :)

![CleanShot 2023-12-10 at 09 29 14@2x](https://github.com/Shpigford/gemfile.directory/assets/311936/12b65905-9729-47a0-b195-304ac014bbce)
