### PR TITLE
Use right size for user.image and extract submitted by logic

### DIFF
--- a/app/helpers/gemfiles_helper.rb
+++ b/app/helpers/gemfiles_helper.rb
@@ -1,2 +1,21 @@
 module GemfilesHelper
+  def gemfile_submitted_by(user)
+    concat("Submitted by ")
+
+    tag.span(class: "flex item-center ml-2 space-x-1") do
+      concat(image_tag user_image_url(user, size: 16), class: "w-4 h-4 rounded-full")
+
+      concat(
+        tag.b do
+          if user.x_username.present?
+            link_to "@#{user.x_username}", "https://x.com/#{user.x_username}", class: 'hover:underline'
+          elsif user.github_username.present?
+            link_to "@#{user.github_username}", "https://github.com/#{user.github_username}", class: 'hover:underline'
+          else
+            user.name
+          end
+        end
+      )
+    end
+  end
 end

--- a/app/helpers/gemfiles_helper.rb
+++ b/app/helpers/gemfiles_helper.rb
@@ -3,7 +3,7 @@ module GemfilesHelper
     concat("Submitted by ")
 
     tag.span(class: "flex item-center ml-2 space-x-1") do
-      concat(image_tag user_image_url(user, size: 16), class: "w-4 h-4 rounded-full")
+      concat(image_tag user_image_url(user, size: 32), class: "w-4 h-4 rounded-full")
 
       concat(
         tag.b do

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,11 @@
+module UserHelper
+  def user_image_url(user, size: nil)
+    return user.image unless size
+
+    uri = URI.parse(user.image)
+    new_query_ar = URI.decode_www_form(uri.query || '') << ["s", size]
+    uri.query = URI.encode_www_form(new_query_ar)
+
+    uri.to_s
+  end
+end

--- a/app/views/gemfiles/_gemfile_list_item.html.erb
+++ b/app/views/gemfiles/_gemfile_list_item.html.erb
@@ -8,15 +8,7 @@
     </p>
     <div class="flex items-center mt-1 text-xs leading-5 text-gray-500 gap-x-2">
       <p class="flex">
-        Submitted by <span class="flex items-center ml-2 space-x-1"><%= image_tag gemfile.user.image, class: 'w-4 h-4 rounded-full' %> <b>
-        <% if gemfile.user.x_username.present? %>
-          <%= link_to "@#{gemfile.user.x_username}", "https://x.com/#{gemfile.user.x_username}", class: 'hover:underline' %>
-        <% elsif gemfile.user.github_username.present? %>
-          <%= link_to "@#{gemfile.user.github_username}", "https://github.com/#{gemfile.user.github_username}", class: 'hover:underline' %>
-        <% else %>
-          <%= gemfile.user.name %>
-        <% end %>
-        </b></span>
+        <%= gemfile_submitted_by(gemfile.user) %>
       </p>
       <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current">
         <circle cx="1" cy="1" r="1" />

--- a/app/views/gemfiles/show.html.erb
+++ b/app/views/gemfiles/show.html.erb
@@ -19,15 +19,7 @@
           <% end %>
         </div>
         <div class="flex items-center text-sm text-white">
-          Submitted by <span class="flex items-center ml-2 space-x-1"><%= image_tag @gemfile.user.image, class: 'w-4 h-4 rounded-full' %> <b>
-          <% if @gemfile.user.x_username.present? %>
-            <%= link_to "@#{@gemfile.user.x_username}", "https://x.com/#{@gemfile.user.x_username}", class: 'hover:underline' %>
-          <% elsif @gemfile.user.github_username.present? %>
-            <%= link_to "@#{@gemfile.user.github_username}", "https://github.com/#{@gemfile.user.github_username}", class: 'hover:underline' %>
-          <% else %>
-            <%= @gemfile.user.name %>
-          <% end %>
-          </b></span>
+          <%= gemfile_submitted_by(@gemfile.user) %>
         </div>
         <% if @gemfile.notes.present? %>
           <p class="mt-3 text-xs italic text-white"><%= @gemfile.notes %></p>

--- a/app/views/gems/show.html.erb
+++ b/app/views/gems/show.html.erb
@@ -29,15 +29,7 @@
       </p>
       <div class="flex items-center mt-1 text-xs leading-5 text-gray-500 gap-x-2">
         <p class="flex">
-          Submitted by <span class="flex items-center ml-2 space-x-1"><%= image_tag gemfile.user.image, class: 'w-4 h-4 rounded-full' %> <b>
-          <% if gemfile.user.x_username.present? %>
-            <%= link_to "@#{gemfile.user.x_username}", "https://x.com/#{gemfile.user.x_username}", class: 'hover:underline' %>
-          <% elsif gemfile.user.github_username.present? %>
-            <%= link_to "@#{gemfile.user.github_username}", "https://github.com/#{gemfile.user.github_username}", class: 'hover:underline' %>
-          <% else %>
-            <%= gemfile.user.name %>
-          <% end %>
-          </b></span>
+          <%= gemfile_submitted_by(gemfile.user) %>
         </p>
         <svg viewBox="0 0 2 2" class="h-0.5 w-0.5 fill-current">
           <circle cx="1" cy="1" r="1" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -118,7 +118,7 @@
                       <button type="button" class="relative flex text-sm text-white rounded-full bg-neutral-600 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-neutral-600" id="user-menu-button" aria-expanded="false" aria-haspopup="true" data-action="dropdown#toggle click@window->dropdown#hide">
                         <span class="absolute -inset-1.5"></span>
                         <span class="sr-only">Open user menu</span>
-                        <%= image_tag current_user.image, class: 'w-8 h-8 rounded-full' %>
+                        <%= image_tag user_image_url(current_user, size: 32), class: 'w-8 h-8 rounded-full' %>
                       </button>
                     </div>
 


### PR DESCRIPTION
## Description

The user.image is used directly on all cases and just re-sizing it with css. The default size of the image is 460x460 and the project uses 32x32 and 16x16 so in favor of use the right size for browser performance, the `user_image_url` helper was created  to attach the  `s` query parameter to the URL so we can request the image in the size we want.

The second change is the extraction of the submitted by logic. That logic was spread in three different files, so the best option to avoid copy/paste is to move it to a helper (`gemfile_submitted_by`) and re-use it when it's needed it.