### PR TITLE
Lazy load controllers

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,12 +3,12 @@
 import { application } from "controllers/application"
 
 // Eager load all controllers defined in the import map under controllers/**/*_controller
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
-eagerLoadControllersFrom("controllers", application)
+// import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+// eagerLoadControllersFrom("controllers", application)
 
 // Lazy load controllers as they appear in the DOM (remember not to preload controllers in import map!)
-// import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
-// lazyLoadControllersFrom("controllers", application)
+import { lazyLoadControllersFrom } from "@hotwired/stimulus-loading"
+lazyLoadControllersFrom("controllers", application)
 
 import Dropdown from 'stimulus-dropdown'
 application.register('dropdown', Dropdown)

--- a/app/views/gemfiles/show.html.erb
+++ b/app/views/gemfiles/show.html.erb
@@ -3,6 +3,10 @@
   header_title @gemfile.name
 %>
 
+<%= content_for(:head) do %>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/arta.min.css">
+<% end %>
+
 <% header_content do %>
     <div class="flex">
       <div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/arta.min.css">
+    <%= yield(:head) %>
 
     <script>
       // document.addEventListener('turbo:load', () => {

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,12 +1,16 @@
 # Pin npm packages by running ./bin/importmap
 
+# Preloaded Packages
 pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js"
+pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
-pin_all_from "app/javascript/controllers", under: "controllers"
+
+# NOT Preloaded Packages
 pin "stimulus-dropdown", to: "https://ga.jspm.io/npm:stimulus-dropdown@2.1.0/dist/stimulus-dropdown.mjs"
 pin "hotkeys-js", to: "https://ga.jspm.io/npm:hotkeys-js@3.12.2/dist/hotkeys.esm.js"
 pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.51.3/dist/index.js"
 pin "stimulus-reveal-controller", to: "https://ga.jspm.io/npm:stimulus-reveal-controller@4.1.0/dist/stimulus-reveal-controller.mjs"
 pin "highlight.js", to: "https://ga.jspm.io/npm:highlight.js@11.9.0/es/index.js"
+
+pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
## Description

Currently controllers are loaded automatically doing `eagerLoadControllersFrom` that loads every controller on every page always. With this change they will be loaded lazy by the use of `lazyLoadControllersFrom`. In favor of load just what the page needs, the css files required by highlight now are loaded only on gemfile#show given is the only page using it.